### PR TITLE
Don't bind to specific json-editor version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
         "node_modules"
     ],
     "dependencies": {
-        "json-editor": "~0.7.13",
+        "json-editor": "^0.7.13",
         "angular": "1.*"
     }
 }


### PR DESCRIPTION
This patch allows patch and minor version updates but disallows major (1.0.0) json-editor updates.
